### PR TITLE
Typo fix: insuffient -> insufficient

### DIFF
--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -166,7 +166,7 @@ msgstr ""
 
 #: octoprint_pi_support/static/js/pi_support.js:70
 msgid ""
-"Your Raspberry Pi is reporting insuffient power. Switch to an adequate "
+"Your Raspberry Pi is reporting insufficient power. Switch to an adequate "
 "power supply or risk bad performance and failed prints."
 msgstr ""
 


### PR DESCRIPTION
Small typo fix in this strings file. It looks like the underlying JS file has already been updated.

I did not touch any of the translation files, as although the typo is also there in e.g. `de`, the message is also in English.

Thanks for the great project!